### PR TITLE
Create homepage for snake and apple store clone

### DIFF
--- a/snake-mobile/src/app/layout.tsx
+++ b/snake-mobile/src/app/layout.tsx
@@ -13,8 +13,11 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "Snake Mobile",
-  description: "Play Snake on mobile or desktop.",
+  title: {
+    default: "Accueil",
+    template: "%s · Jeux & Démos",
+  },
+  description: "Jouer à Snake et bientôt un clone d'une page Apple Store.",
 };
 
 export default function RootLayout({

--- a/snake-mobile/src/app/page.tsx
+++ b/snake-mobile/src/app/page.tsx
@@ -1,12 +1,26 @@
-import SnakeGame from "@/components/SnakeGame";
+import Link from "next/link";
 
 export default function Home() {
   return (
-    <div className="min-h-screen p-4 flex items-center justify-center">
-      <div className="w-full max-w-[560px] flex flex-col items-center gap-4">
-        <h1 className="text-2xl font-semibold">Snake Mobile</h1>
-        <SnakeGame />
+    <main className="min-h-screen p-6 flex items-center justify-center">
+      <div className="w-full max-w-[720px] mx-auto flex flex-col gap-6">
+        <header className="flex flex-col gap-1">
+          <h1 className="text-3xl font-semibold">Accueil</h1>
+          <p className="opacity-80">Choisissez une expérience.</p>
+        </header>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <Link href="/snake" className="rounded-lg border border-black/[.08] dark:border-white/[.145] p-4 hover:bg-black/[.02] dark:hover:bg-white/[.02] transition-colors">
+            <div className="text-lg font-medium">Jouer à Snake</div>
+            <p className="text-sm opacity-75">Version mobile et desktop</p>
+          </Link>
+
+          <div className="rounded-lg border border-black/[.08] dark:border-white/[.145] p-4 opacity-60">
+            <div className="text-lg font-medium">Apple Store (bientôt)</div>
+            <p className="text-sm opacity-75">Clone d&apos;une page de l&apos;Apple&nbsp;Store</p>
+          </div>
+        </div>
       </div>
-    </div>
+    </main>
   );
 }

--- a/snake-mobile/src/app/snake/page.tsx
+++ b/snake-mobile/src/app/snake/page.tsx
@@ -1,0 +1,18 @@
+import Link from "next/link";
+import SnakeGame from "@/components/SnakeGame";
+
+export default function SnakePage() {
+  return (
+    <div className="min-h-screen p-4 flex items-center justify-center">
+      <div className="w-full max-w-[560px] flex flex-col items-center gap-4">
+        <div className="w-full flex items-center justify-between">
+          <Link href="/" className="text-sm opacity-80 hover:opacity-100">← Accueil</Link>
+          <h1 className="text-2xl font-semibold">Snake</h1>
+          <div className="w-14" />
+        </div>
+        <SnakeGame />
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
Adds a new home page with links to the Snake game and a placeholder for a future Apple Store clone.

---
<a href="https://cursor.com/background-agent?bcId=bc-cc9db91b-18f3-4ff1-8ede-91cc820de030">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cc9db91b-18f3-4ff1-8ede-91cc820de030">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

